### PR TITLE
Update output to latest jruby-kafka.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -23,7 +23,7 @@ See http://kafka.apache.org/documentation.html#producerconfigs for details about
             partitioner_class => ... # string (optional) default: "kafka.producer.DefaultPartitioner"
             request_timeout_ms => ... # number (optional) default: 10000
             producer_type => ... # string (optional), one of ["sync", "async"] default => 'sync'
-            key_serializer_class => ... # string (optional) default: nil
+            key_serializer_class => ... # string (optional) default: kafka.serializer.StringEncoder
             message_send_max_retries => ... # number (optional) default: 3
             retry_backoff_ms => ... # number (optional) default: 100
             topic_metadata_refresh_interval_ms => ... # number (optional) default: 600 * 1000
@@ -33,6 +33,7 @@ See http://kafka.apache.org/documentation.html#producerconfigs for details about
             batch_num_messages => ... # number (optional) default: 200
             send_buffer_bytes => ... # number (optional) default: 100 * 1024
             client_id => ... # string (optional) default: ""
+            partition_key_format => ... # string (optional) default: nil, Provides a way to specify a partition key as a string
         }
     }
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -136,8 +136,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
         :queue_enqueue_timeout_ms => @queue_enqueue_timeout_ms,
         :batch_num_messages => @batch_num_messages,
         :send_buffer_bytes => @send_buffer_bytes,
-        :client_id => @client_id,
-        :partition_key_format => @partition_key_format
+        :client_id => @client_id
     }
     @producer = Kafka::Producer.new(options)
     @producer.connect

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -19,10 +19,6 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { 'logstash_plugin' => 'true', 'group' => 'output'}
 
-  # Jar dependencies
-  s.requirements << "jar 'org.apache.kafka:kafka_2.9.2', '0.8.1.1'"
-  s.requirements << "jar 'org.slf4j:slf4j-log4j12', '1.7.10'"
-
   # Gem dependencies
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
   s.add_runtime_dependency 'logstash-codec-plain'
@@ -39,6 +35,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ruby-maven', '3.1.1.0.8'
   s.add_runtime_dependency "maven-tools", '1.0.7'
 
-  s.add_runtime_dependency 'jruby-kafka', ['>=0.2.1']
+  s.add_runtime_dependency 'jruby-kafka', ['>= 1.1.0', '< 2.0.0']
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/outputs/kafka_spec.rb
+++ b/spec/outputs/kafka_spec.rb
@@ -1,13 +1,12 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require 'logstash/outputs/kafka'
-require 'logstash-output-kafka_jars'
 require 'jruby-kafka'
 require 'json'
 
 describe "outputs/kafka" do
   let (:simple_kafka_config) {{'topic_id' => 'test'}}
-  let (:event) { LogStash::Event.new({'message' => 'hello', 'topic_name' => 'my_topic',
+  let (:event) { LogStash::Event.new({'message' => 'hello', 'topic_name' => 'my_topic', 'host' => '172.0.0.1',
                                       '@timestamp' => LogStash::Timestamp.now}) }
 
   context 'when initializing' do
@@ -41,6 +40,16 @@ describe "outputs/kafka" do
       expect_any_instance_of(Kafka::Producer).to receive(:send_msg)
         .with(event[topic_field], nil, event.to_hash.to_json)
       kafka = LogStash::Outputs::Kafka.new({'topic_id' => "%{#{topic_field}}"})
+      kafka.register
+      kafka.receive(event)
+    end
+
+    it 'should support Event#sprintf placeholders in partition_key_format' do
+      partition_field = 'host'
+      expect_any_instance_of(Kafka::Producer).to receive(:send_msg)
+        .with(simple_kafka_config['topic_id'], event[partition_field], event.to_hash.to_json)
+      kafka = LogStash::Outputs::Kafka.new({'topic_id' => simple_kafka_config['topic_id'],
+                                            'partition_key_format' => "%{#{partition_field}}"})
       kafka.register
       kafka.receive(event)
     end


### PR DESCRIPTION
This brings in the latest jruby-kafka as well as partition key selection via the key_serializer_class
necessary jars are now bundled in jruby-kafka gem