### PR TITLE
call to_json on Event, not the hash of an Event in tests

### DIFF
--- a/spec/outputs/kafka_spec.rb
+++ b/spec/outputs/kafka_spec.rb
@@ -29,7 +29,7 @@ describe "outputs/kafka" do
   context 'when outputting messages' do
     it 'should send logstash event to kafka broker' do
       expect_any_instance_of(Kafka::Producer).to receive(:send_msg)
-        .with(simple_kafka_config['topic_id'], nil, event.to_hash.to_json)
+        .with(simple_kafka_config['topic_id'], nil, event.to_json)
       kafka = LogStash::Outputs::Kafka.new(simple_kafka_config)
       kafka.register
       kafka.receive(event)
@@ -38,7 +38,7 @@ describe "outputs/kafka" do
     it 'should support Event#sprintf placeholders in topic_id' do
       topic_field = 'topic_name'
       expect_any_instance_of(Kafka::Producer).to receive(:send_msg)
-        .with(event[topic_field], nil, event.to_hash.to_json)
+        .with(event[topic_field], nil, event.to_json)
       kafka = LogStash::Outputs::Kafka.new({'topic_id' => "%{#{topic_field}}"})
       kafka.register
       kafka.receive(event)
@@ -47,7 +47,7 @@ describe "outputs/kafka" do
     it 'should support Event#sprintf placeholders in partition_key_format' do
       partition_field = 'host'
       expect_any_instance_of(Kafka::Producer).to receive(:send_msg)
-        .with(simple_kafka_config['topic_id'], event[partition_field], event.to_hash.to_json)
+        .with(simple_kafka_config['topic_id'], event[partition_field], event.to_json)
       kafka = LogStash::Outputs::Kafka.new({'topic_id' => simple_kafka_config['topic_id'],
                                             'partition_key_format' => "%{#{partition_field}}"})
       kafka.register


### PR DESCRIPTION
fixes a weird test failure that only occurs when running these tests alongside other conflicting plugins.