### PR TITLE
Update example configuration snippet in kafka.rb

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -46,6 +46,7 @@ the output configuration something like:
             codec => plain {
                 format => "%{message}"
             }
+            topic_id => "my_topic_id"
         }
     }
     

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -16,7 +16,7 @@ require 'jruby-kafka'
 #         codec => plain {
 #            format => "%{message}"
 #         }
-#         topic => "mytopic"
+#         topic_id => "mytopic"
 #       }
 #     }
 # For more information see http://kafka.apache.org/documentation.html#theproducer

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -16,6 +16,7 @@ require 'jruby-kafka'
 #         codec => plain {
 #            format => "%{message}"
 #         }
+#         topic => "mytopic"
 #       }
 #     }
 # For more information see http://kafka.apache.org/documentation.html#theproducer


### PR DESCRIPTION
The example configuration snippet is wrong according to the documentation below it.
If `topic` is the only required setting, it should be contained in the configuration example.