### PR TITLE
Add SSL options to producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.0.0.beta1
+ - Note: breaking changes in this version, and not backward compatible with Kafka 0.8 broker. 
+   Please read carefully before installing
+ - Breaking: Changed default codec from json to plain. Json codec is really slow when used 
+   with inputs because inputs by default are single threaded. This makes it a bad
+   first user experience. Plain codec is a much better default. 
+ - Moved internal APIs to use Kafka's Java API directly instead of jruby-kafka. This
+   makes it consistent with logstash-input-kafka
+ - Breaking: Change in configuration options
+ - Added SSL options so you can connect securely to a 0.9 Kafka broker
+
 ## 2.0.2
  - [Internal] Pin jruby-kafka to v1.5
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -169,6 +169,9 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       props.put(kafka::VALUE_SERIALIZER_CLASS_CONFIG, value_serializer)
       
       if ssl
+        if ssl_truststore_location.nil?
+          raise LogStash::ConfigurationError, "ssl_truststore_location must be set when SSL is enabled"
+        end
         props.put("security.protocol", "SSL")
         props.put("ssl.truststore.location", ssl_truststore_location)
         props.put("ssl.truststore.password", ssl_truststore_password.value) unless ssl_truststore_password.nil?
@@ -181,7 +184,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       org.apache.kafka.clients.producer.KafkaProducer.new(props)
     rescue => e
       logger.error("Unable to create Kafka producer from given configuration", :kafka_error_message => e)
-      throw e
+      raise e
     end
   end
 

--- a/spec/unit/outputs/kafka_spec.rb
+++ b/spec/unit/outputs/kafka_spec.rb
@@ -49,5 +49,10 @@ describe "outputs/kafka" do
       kafka.register
       kafka.receive(event)
     end
+    
+    it 'should raise config error when truststore location is not set and ssl is enabled' do
+      kafka = LogStash::Outputs::Kafka.new(simple_kafka_config.merge({"ssl" => "true"}))
+      expect { kafka.register }.to raise_error(LogStash::ConfigurationError, /ssl_truststore_location must be set when SSL is enabled/)
+    end
   end
 end


### PR DESCRIPTION
According to https://kafka.apache.org/documentation.html#security_configclients
SSL options are the same for producer and consumers so these options
are consistent with logstash-input-kafka