### PR TITLE
Too many connections to Kafka nodes

### DIFF
--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -117,6 +117,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   public
   def register
     unless defined? @@producer
+      @logger.debug('First call to the Kafka output class, Kafka producer will be created.')
       @@producer = create_producer
     end
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -116,7 +116,10 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
   public
   def register
-    @producer = create_producer
+    unless defined? @@producer
+      @@producer = create_producer
+    end
+
     @codec.on_event do |event, data|
       begin
         if @message_key.nil?
@@ -124,7 +127,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
         else
           record = org.apache.kafka.clients.producer.ProducerRecord.new(event.sprintf(@topic_id), event.sprintf(@message_key), data)
         end
-        @producer.send(record)
+        @@producer.send(record)
       rescue LogStash::ShutdownSignal
         @logger.info('Kafka producer got shutdown signal')
       rescue => e
@@ -143,7 +146,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   end
 
   def close
-    @producer.close
+    @@producer.close
   end
 
   private


### PR DESCRIPTION
I change the visibility of the producer in order to limit the number of connections to the Kafka cluster and enhance performances.

https://kafka.apache.org/090/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html
"The producer is thread safe and sharing a single producer instance across threads will generally be faster than having multiple instances. "