### PR TITLE
Too many connections to kafka cluster

### DIFF
--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -117,6 +117,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   public
   def register
     unless defined? @@producer
+      @logger.debug('First call to the Kafka output class, Kafka producer will be created.')
       @@producer = create_producer
     end
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -117,7 +117,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   public
   def register
     unless defined? @@producer
-      @logger.debug('First call to the Kafka output class, Kafka producer will be created.')
+      @logger.debug('First call to the Kafka output class. Kafka producer will be created.')
       @@producer = create_producer
     end
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -116,7 +116,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
   public
   def register
-    unless defined? @@producer
+    if (defined?(@@producer) == nil) or @@producer.nil?
       @logger.debug('First call to the Kafka output class. Kafka producer will be created.')
       @@producer = create_producer
     end

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -116,7 +116,10 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
   public
   def register
-    @producer = create_producer
+    unless defined? @@producer
+      @@producer = create_producer
+    end
+
     @codec.on_event do |event, data|
       begin
         if @message_key.nil?
@@ -124,7 +127,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
         else
           record = org.apache.kafka.clients.producer.ProducerRecord.new(event.sprintf(@topic_id), event.sprintf(@message_key), data)
         end
-        @producer.send(record)
+        @@producer.send(record)
       rescue LogStash::ShutdownSignal
         @logger.info('Kafka producer got shutdown signal')
       rescue => e
@@ -143,7 +146,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   end
 
   def close
-    @producer.close
+    @@producer.close
   end
 
   private

--- a/spec/unit/outputs/kafka_spec.rb
+++ b/spec/unit/outputs/kafka_spec.rb
@@ -8,20 +8,6 @@ describe "outputs/kafka" do
   let (:event) { LogStash::Event.new({'message' => 'hello', 'topic_name' => 'my_topic', 'host' => '172.0.0.1',
                                       '@timestamp' => LogStash::Timestamp.now}) }
 
-  context 'when initializing' do
-    it "should register" do
-      output = LogStash::Plugin.lookup("output", "kafka").new(simple_kafka_config)
-      expect {output.register}.to_not raise_error
-    end
-
-    it 'should populate kafka config with default values' do
-      kafka = LogStash::Outputs::Kafka.new(simple_kafka_config)
-      insist {kafka.bootstrap_servers} == 'localhost:9092'
-      insist {kafka.topic_id} == 'test'
-      insist {kafka.key_serializer} == 'org.apache.kafka.common.serialization.StringSerializer'
-    end
-  end
-
   context 'when outputting messages' do
     it 'should send logstash event to kafka broker' do
       expect_any_instance_of(org.apache.kafka.clients.producer.KafkaProducer).to receive(:send)
@@ -49,10 +35,25 @@ describe "outputs/kafka" do
       kafka.register
       kafka.receive(event)
     end
-    
+
     it 'should raise config error when truststore location is not set and ssl is enabled' do
       kafka = LogStash::Outputs::Kafka.new(simple_kafka_config.merge({"ssl" => "true"}))
       expect { kafka.register }.to raise_error(LogStash::ConfigurationError, /ssl_truststore_location must be set when SSL is enabled/)
     end
   end
+
+  context 'when initializing' do
+    it "should register" do
+      output = LogStash::Plugin.lookup("output", "kafka").new(simple_kafka_config)
+      expect {output.register}.to_not raise_error
+    end
+
+    it 'should populate kafka config with default values' do
+      kafka = LogStash::Outputs::Kafka.new(simple_kafka_config)
+      insist {kafka.bootstrap_servers} == 'localhost:9092'
+      insist {kafka.topic_id} == 'test'
+      insist {kafka.key_serializer} == 'org.apache.kafka.common.serialization.StringSerializer'
+    end
+  end
+
 end


### PR DESCRIPTION
I change the visibility of the producer in order to limit the number of connections to the Kafka cluster and enhance performances.

https://kafka.apache.org/090/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html
"The producer is thread safe and sharing a single producer instance across threads will generally be faster than having multiple instances. "
