### PR TITLE
Alias the install_jars method to vendor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,5 @@ before_install:
   topic3 --zookeeper localhost:2181
 before_script:
 - bundle exec rake vendor
-- bundle exec rake install_jars
 script: bundle exec rspec && bundle exec rspec --tag integration
 jdk: oraclejdk8

--- a/Rakefile
+++ b/Rakefile
@@ -14,3 +14,4 @@ task :install_jars do
   Jars::Installer.new.vendor_jars!(false)
 end
 
+task :vendor => :install_jars


### PR DESCRIPTION
Our build bot and our mass publish process require a unified way of
making the gem and will execute the following tasks:

```
bundle install
bundle exec rake vendor
bundle exec rspec
```
This PR alias the `install_jars` to vendor to make it uniform with our
other tools.