### PR TITLE
initialize kafka producer only if not defined yet.

### DIFF
--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -131,7 +131,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
   public
   def register
-    @producer = create_producer
+    @producer = create_producer if @producer.nil?
     @codec.on_event do |event, data|
       begin
         if @message_key.nil?

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -128,6 +128,8 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   config :topic_id, :validate => :string, :required => true
   # Serializer class for the value of the message
   config :value_serializer, :validate => :string, :default => 'org.apache.kafka.common.serialization.StringSerializer'
+  
+  @@producer = nil
 
   public
   def register

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -131,7 +131,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
   public
   def register
-    @producer = create_producer if @producer.nil?
+    @@producer = create_producer if @@producer.nil?
     @codec.on_event do |event, data|
       begin
         if @message_key.nil?
@@ -139,7 +139,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
         else
           record = org.apache.kafka.clients.producer.ProducerRecord.new(event.sprintf(@topic_id), event.sprintf(@message_key), data)
         end
-        @producer.send(record)
+        @@producer.send(record)
       rescue LogStash::ShutdownSignal
         @logger.info('Kafka producer got shutdown signal')
       rescue => e
@@ -158,7 +158,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   end
 
   def close
-    @producer.close
+    @@producer.close
   end
 
   private


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

In case of multiple worker for the output, the producer is now instantiate only one time in order to avoid too many connections unused on the broker. It's the recommended way to use the org.apache.kafka.clients.producer.KafkaProducer class as explained in https://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html.