### PR TITLE
Create a new class in charge of the kafka producer creation.

### DIFF
--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -160,7 +160,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   end
 
   def close
-    @producer_factory.release_producer(producer)
+    @producer_factory.release_producer(@producer)
   end
 
   private

--- a/lib/logstash/outputs/kafka_producer_factory.rb
+++ b/lib/logstash/outputs/kafka_producer_factory.rb
@@ -1,0 +1,71 @@
+# encoding: utf-8
+require 'singleton'
+require 'logstash/namespace'
+require 'logstash/logging'
+require 'java'
+require 'logstash-output-kafka_jars.rb'
+require 'thread'
+
+#
+# Simple class whicj is responsible for kafka producers management.
+#
+class LogStash::Outputs::KafkaProducerFactory  
+
+  include Singleton
+
+  def initialize
+    # Initialize a mutex to use for thread safe
+    @semaphore = Mutex.new
+    # This var will be used to store producers objects, configurations and usage counter.
+    @definitions = Array.new
+  end
+
+  def hold_producer(props)
+    producer = nil
+   
+    @semaphore.synchronize {
+      # Search for an existing definition matching the props parameter
+      @definitions.each { |d|
+        if d[:config].equals(props)
+          producer = d[:producer]
+          d[:usage] += 1
+          break
+        end
+      }
+
+      # If no definition have been found, we insert a new one
+      if producer == nil
+        producer = org.apache.kafka.clients.producer.KafkaProducer.new(props)
+        @definitions.push({ :producer => producer, :usage => 1, :config => props})
+      end
+    }
+
+    return producer
+  end
+
+  def release_producer(producer)
+    definition = nil
+
+    @semaphore.synchronize {
+      # Search for the definition matching the specified producer
+      @definitions.each { |d|
+        if d[:producer].equals(producer)
+          definition = d
+          break
+        end
+      }
+
+      definition[:usage] -= 1
+
+      # Remove definitions that won't be used anymore
+      if definition[:usage] == 0 
+        @definitions.delete(definition)
+      end     
+    }
+
+    # Close producer that won't be used anymore outside of the semaphore as this function could be long
+    if definition[:usage] == 0
+      definition[:producer].close
+    end
+  end
+end

--- a/spec/unit/outputs/kafka_producer_factory_spec.rb
+++ b/spec/unit/outputs/kafka_producer_factory_spec.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+require 'logstash/outputs/kafka_producer_factory'
+require 'java'
+
+describe "outputs/kafka_producer_factory" do
+
+  before do
+      props = java.util.Properties.new 
+      props.put("bootstrap.servers", "localhost:4242");
+      props.put("acks", "all");
+      props.put("retries", "0");
+      props.put("batch.size", "16384");
+      props.put("linger.ms", "1");
+      props.put("buffer.memory", "33554432");
+      props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+      props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+      props1 = props.clone
+      props2 = props.clone
+      props3 = props.clone
+      props3.put("bootstrap.servers", "localhost:4244");
+      @producer1 = LogStash::Outputs::KafkaProducerFactory.instance.hold_producer(props1)
+      @producer2 = LogStash::Outputs::KafkaProducerFactory.instance.hold_producer(props2)
+      @producer3 = LogStash::Outputs::KafkaProducerFactory.instance.hold_producer(props3)
+  end
+
+  it 'should provide the same producer for two identical configs' do
+    expect(@producer1).to equal(@producer2)
+  end
+
+  it 'should provide the different producer for two different configs' do
+    expect(@producer1).not_to equal(@producer3)
+  end
+
+end

--- a/spec/unit/outputs/kafka_producer_factory_spec.rb
+++ b/spec/unit/outputs/kafka_producer_factory_spec.rb
@@ -5,22 +5,27 @@ require 'java'
 describe "outputs/kafka_producer_factory" do
 
   before do
-      props = java.util.Properties.new 
-      props.put("bootstrap.servers", "localhost:4242");
-      props.put("acks", "all");
-      props.put("retries", "0");
-      props.put("batch.size", "16384");
-      props.put("linger.ms", "1");
-      props.put("buffer.memory", "33554432");
-      props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-      props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-      props1 = props.clone
-      props2 = props.clone
-      props3 = props.clone
-      props3.put("bootstrap.servers", "localhost:4244");
+      @props = java.util.Properties.new 
+      @props.put("bootstrap.servers", "localhost:4242");
+      @props.put("acks", "all");
+      @props.put("retries", "0");
+      @props.put("batch.size", "16384");
+      @props.put("linger.ms", "1");
+      @props.put("buffer.memory", "33554432");
+      @props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+      @props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+      props1 = @props.clone
+      props2 = @props.clone
+      props3 = @props.clone
+      props3.put("bootstrap.servers", "localhost:4243");
       @producer1 = LogStash::Outputs::KafkaProducerFactory.instance.hold_producer(props1)
       @producer2 = LogStash::Outputs::KafkaProducerFactory.instance.hold_producer(props2)
       @producer3 = LogStash::Outputs::KafkaProducerFactory.instance.hold_producer(props3)
+      LogStash::Outputs::KafkaProducerFactory.instance.release_producer(@producer2)
+      LogStash::Outputs::KafkaProducerFactory.instance.release_producer(@producer3)
+      @producer4 = LogStash::Outputs::KafkaProducerFactory.instance.hold_producer(props3)
+      @producer5 = LogStash::Outputs::KafkaProducerFactory.instance.hold_producer(props2)
+      
   end
 
   it 'should provide the same producer for two identical configs' do
@@ -29,6 +34,14 @@ describe "outputs/kafka_producer_factory" do
 
   it 'should provide the different producer for two different configs' do
     expect(@producer1).not_to equal(@producer3)
+  end
+
+  it 'should provide different producer for two identical configs when use count has been set to 0 between producers creation' do
+    expect(@producer4).not_to equal(@producer3)
+  end
+
+  it 'should provide the same producer for two identical configs when use count has not been set to 0 between producer creation' do
+    expect(@producer5).to equal(@producer1)
   end
 
 end


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

This way, worker using the same configuration will use the
same kafka producer object.

This will improve the performances as explained here :
https://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/producer/KafkaProducer

Fix issue : https://github.com/elastic/logstash/issues/4754