### PR TITLE
declare plugin as threadsafe to avoid multiple producers when workers > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.2
+  - Declare plugin as threadsafe
+
 ## 5.0.1
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -39,6 +39,8 @@ require 'logstash-output-kafka_jars.rb'
 #
 # Kafka producer configuration: http://kafka.apache.org/documentation.html#newproducerconfigs
 class LogStash::Outputs::Kafka < LogStash::Outputs::Base
+  declare_threadsafe!
+
   config_name 'kafka'
 
   default :codec, 'plain'

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '5.0.1'
+  s.version         = '5.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'Output events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Closes #77.

Kafka's New Java Producer is threadsafe and more efficient if used as a singleton. Declaring this plugin as threadsafe enables leveraging this fact when setting `workers => N` where `N > 1`.

### Default
```
kafka {
  topic_id => "test"
}
```

![screen shot 2016-07-20 at 2 15 18 pm](https://cloud.githubusercontent.com/assets/388837/17003523/3816b7c0-4e85-11e6-89fc-d3f8ea557942.png)

### Workers set to 5
```
kafka {
  topic_id => "test"
  workers => 5
}
```
![screen shot 2016-07-20 at 2 16 37 pm](https://cloud.githubusercontent.com/assets/388837/17003521/37d35eee-4e85-11e6-9803-cfcdbef58011.png)

### With new code and workers set to 5
![screen shot 2016-07-20 at 2 17 32 pm](https://cloud.githubusercontent.com/assets/388837/17003522/37d741bc-4e85-11e6-915f-b4bbb8f3cc8d.png)


Only one producer thread is created.
