### PR TITLE
bump to 6.0 and Kafka 0.10.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk: oraclejdk8
 rvm:
   - jruby-1.7.25
 env:
-  - KAFKA_VERSION=0.10.0.1
+  - KAFKA_VERSION=0.10.1.0
 before_install: ./kafka_test_setup.sh
 before_script:
   - bundle exec rake vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.0
+  - BREAKING: update to 0.10.1.0 client protocol. not backwards compatible with 5.0 (protocol versions <= 10.0.0.1)
+
 ## 5.0.5
   - Fix logging
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Here's a table that describes the compatibility matrix for Kafka Broker support.
 | 0.8           | 2.0 - 2.x   | < 3.0.0 | <3.0.0 | Legacy, 0.8 is still popular |
 | 0.9           | 2.0 - 2.3.x   |   3.0.0 | 3.0.0  | Intermediate release before 0.10 that works with old Ruby Event API `[]`  |
 | 0.9          | 2.4, 5.0           |   4.0.0 | 4.0.0  | Intermediate release before 0.10 with new get/set API |
-| 0.10         | 2.4, 5.0           |   5.0.0 | 5.0.0  | Track latest Kafka release. Not compatible with 0.9 broker |
+| 0.10.0.x         | 2.4, 5.0           |   5.0.0 | 5.0.0  | Track latest Kafka release. Not compatible with 0.9 broker |
+| 0.10.1.x         | 2.4, 5.0           |   6.0.0 | X  | Track latest Kafka release. Not compatible with < 0.10.0.x broker |
 
 
 ## Documentation

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -13,11 +13,12 @@ require 'logstash-output-kafka_jars.rb'
 # |==========================================================
 # |Kafka Client Version |Logstash Version |Plugin Version |Security Features |Why?
 # |0.8       |2.0.0 - 2.x.x   |<3.0.0 | |Legacy, 0.8 is still popular 
-# |0.9       |2.0.0 - 2.3.x   | 3.x.x |Basic Auth, SSL |Works with the old Ruby Event API (`event['product']['price'] = 10`)  
+# |0.9       |2.0.0 - 2.3.x   | 3.x.x |Basic Auth, SSL |Works with the old Ruby Event API (`event['product']['price'] = 10`)
 # |0.9       |2.4.0 - 5.0.x   | 4.x.x |Basic Auth, SSL |Works with the new getter/setter APIs (`event.set('[product][price]', 10)`)
-# |0.10      |2.4.0 - 5.0.x   | 5.x.x |Basic Auth, SSL |Not compatible with the 0.9 broker 
+# |0.10.0.x  |2.4.0 - 5.0.x   | 5.x.x |Basic Auth, SSL |Not compatible with the <= 0.9 broker
+# |0.10.1.x  |2.4.0 - 5.0.x   | 6.x.x |Basic Auth, SSL |Not compatible with <= 0.10.0.x broker
 # |==========================================================
-# 
+#
 # NOTE: We recommended that you use matching Kafka client and broker versions. During upgrades, you should
 # upgrade brokers before clients because brokers target backwards compatibility. For example, the 0.9 broker
 # is compatible with both the 0.8 consumer and 0.9 consumer APIs, but not the other way around.

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '5.0.6'
+  s.version         = '6.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'Output events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { 'logstash_plugin' => 'true', 'group' => 'output'}
 
-  s.requirements << "jar 'org.apache.kafka:kafka-clients', '0.10.0.1'"
-  s.requirements << "jar 'org.slf4j:slf4j-log4j12', '1.7.13'"
+  s.requirements << "jar 'org.apache.kafka:kafka-clients', '0.10.1.0'"
+  s.requirements << "jar 'org.slf4j:slf4j-log4j12', '1.7.21'"
 
   s.add_development_dependency 'jar-dependencies', '~> 0.3.2'
 


### PR DESCRIPTION
new release of Kafka 0.10.1.0: https://www.confluent.io/blog/announcing-apache-kafka-0-10-1-0/


this PR updates the plugin to support this version of the client protocols