### PR TITLE
dependency logstash-core-plugin-api >= 1.60 <= 2.99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.4
+  - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
+
 ## 4.0.3
   - Internal: vendoring issue when bundling gem
 
@@ -7,7 +10,7 @@
 ## 4.0.0/4.0.1
   - Republish all the gems under jruby.
   - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
-  
+
 ## 3.0.0
  - GA release of Kafka Output to support 0.9 broker
 
@@ -24,16 +27,16 @@
 ## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
   - [Internal] Pin jruby-kafka to v1.6 to match input
-  
+
 ## 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
 
 ## 3.0.0.beta1
- - Note: breaking changes in this version, and not backward compatible with Kafka 0.8 broker. 
+ - Note: breaking changes in this version, and not backward compatible with Kafka 0.8 broker.
    Please read carefully before installing
- - Breaking: Changed default codec from json to plain. Json codec is really slow when used 
+ - Breaking: Changed default codec from json to plain. Json codec is really slow when used
    with inputs because inputs by default are single threaded. This makes it a bad
-   first user experience. Plain codec is a much better default. 
+   first user experience. Plain codec is a much better default.
  - Moved internal APIs to use Kafka's Java API directly instead of jruby-kafka. This
    makes it consistent with logstash-input-kafka
  - Breaking: Change in configuration options
@@ -43,7 +46,7 @@
  - [Internal] Pin jruby-kafka to v1.5
 
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '4.0.3'
+  s.version         = '4.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'Output events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'jar-dependencies', '~> 0.3.2'
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-codec-json'
 


### PR DESCRIPTION
This is a copy of https://github.com/logstash-plugins/logstash-output-kafka/commit/d772a5422e64f727ef10a196ed226784673e5d68 for the `4.x` branch. This dependency is causing installation conflicts in our environments, so please merge unless there really is a dependency on `v2.0` of `logstash-core-plugin-api`