### PR TITLE
bump version dep for sl4j-log4j to 1.7.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.2
+  - bump sl4j version dep to 1.7.21 to align with input plugin and kafka-clients maven deps
+
 ## 5.1.1
   - Update the doc to mention the plain codec instead of the json codec.
 

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '5.1.1'
+  s.version         = '5.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'Output events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { 'logstash_plugin' => 'true', 'group' => 'output'}
 
   s.requirements << "jar 'org.apache.kafka:kafka-clients', '0.10.0.1'"
-  s.requirements << "jar 'org.slf4j:slf4j-log4j12', '1.7.13'"
+  s.requirements << "jar 'org.slf4j:slf4j-log4j12', '1.7.21'"
 
   s.add_development_dependency 'jar-dependencies', '~> 0.3.2'
 


### PR DESCRIPTION
The kafka Client Library: https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients/0.10.0.1
depends on slf4j 1.7.21. The same is the case for logstash-input-kafka
5.1. This PR upgrades the output plugin to reflect this.