### PR TITLE
Fix versions in compatibility matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.1
+  - Docs: Clarify compatibility matrix and remove it from the changelog to avoid duplication.
+
 ## 6.1.0
   - Add Kerberos authentication feature.
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,6 @@ This is a plugin for [Logstash](https://github.com/elastic/logstash).
 
 It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
 
-## Kafka Compatibility
-
-Here's a table that describes the compatibility matrix for Kafka Broker support. Please remember that it is good advice to upgrade brokers before consumers/producers since brokers target backwards compatibility. The 0.9 broker will work with both the 0.8 consumer and 0.9 consumer APIs but not the other way around.
-
-| Kafka Broker Version | Logstash Version | Input Plugin | Output Plugin | Why? |
-|:---------------:|:------------------:|:--------------:|:---------------:|:------|
-| 0.8           | 2.0 - 2.x   | < 3.0.0 | <3.0.0 | Legacy, 0.8 is still popular |
-| 0.9           | 2.0 - 2.3.x   |   3.0.0 | 3.0.0  | Intermediate release before 0.10 that works with old Ruby Event API `[]`  |
-| 0.9          | 2.4, 5.0           |   4.0.0 | 4.0.0  | Intermediate release before 0.10 with new get/set API |
-| 0.10.0.x         | 2.4, 5.0           |   5.0.0 | 5.0.0  | Track latest Kafka release. Not compatible with 0.9 broker |
-| 0.10.1.x         | 2.4, 5.0           |   6.0.0 | X  | Track latest Kafka release. Not compatible with < 0.10.0.x broker |
-
-
 ## Documentation
 
 Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -14,9 +14,9 @@ require 'logstash-output-kafka_jars.rb'
 # |Kafka Client Version |Logstash Version |Plugin Version |Security Features |Why?
 # |0.8       |2.0.0 - 2.x.x   |<3.0.0 | |Legacy, 0.8 is still popular 
 # |0.9       |2.0.0 - 2.3.x   | 3.x.x |SSL |Works with the old Ruby Event API (`event['product']['price'] = 10`)
-# |0.9       |2.4.0 - 5.0.x   | 4.x.x |SSL |Works with the new getter/setter APIs (`event.set('[product][price]', 10)`)
-# |0.10.0.x  |2.4.0 - 5.0.x   | 5.x.x |SSL |Not compatible with the <= 0.9 broker
-# |0.10.1.x  |2.4.0 - 5.0.x   | 6.x.x |SSL |Not compatible with <= 0.10.0.x broker
+# |0.9       |2.4.x - 5.x.x   | 4.x.x |SSL |Works with the new getter/setter APIs (`event.set('[product][price]', 10)`)
+# |0.10.0.x  |2.4.x - 5.x.x   | 5.x.x |SSL |Not compatible with the <= 0.9 broker
+# |0.10.1.x  |2.4.x - 5.x.x   | 6.x.x |SSL |Not compatible with <= 0.10.0.x broker
 # |==========================================================
 #
 # NOTE: We recommended that you use matching Kafka client and broker versions. During upgrades, you should

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '6.1.0'
+  s.version         = '6.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'Output events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixed misleading version info that made customers wonder if LS 5.1 supports Kafka 0.9. Fixed versions to be more generic.

