### PR TITLE
pass properties object for SASL_SSL

### DIFF
--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -234,8 +234,8 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       elsif security_protocol == "SASL_PLAINTEXT"
         set_sasl_config(props)
       elsif security_protocol == "SASL_SSL"
-        set_trustore_keystore_config
-        set_sasl_config
+        set_trustore_keystore_config(props)
+        set_sasl_config(props)
       end
 
 


### PR DESCRIPTION
pass properties object to set_truststore_keystore_config and set_sasl_config for security protocol SASL_SSL
