### PR TITLE
fix kafka docs default codec description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.0.2
+  - Docs: Fix misleading info about the default codec
+
 ## 7.0.1
   - Fix some documentation issues
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -48,19 +48,19 @@ This output supports connecting to Kafka over:
 
 By default security is disabled but can be turned on as needed.
 
-The only required configuration is the topic_id. The default codec is plain,
-so events will be persisted on the broker in plain format. Logstash will encode your messages with not 
-only the message but also with a timestamp and hostname. If you do not want anything but your message 
-passing through, you should make the output configuration something like:
+The only required configuration is the topic_id. 
+
+The default codec is plain. Logstash will encode your events with not only the message field but also with a timestamp and hostname.
+
+If you want the full content of your events to be sent as json, you should set the codec in the output configuration like this:
 [source,ruby]
     output {
       kafka {
-        codec => plain {
-           format => "%{message}"
-        }
+        codec => json
         topic_id => "mytopic"
       }
     }
+    
 For more information see http://kafka.apache.org/documentation.html#theproducer
 
 Kafka producer configuration: http://kafka.apache.org/documentation.html#newproducerconfigs

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '7.0.1'
+  s.version         = '7.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'Output events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Bumps version and adds changelog entry for https://github.com/logstash-plugins/logstash-output-kafka/pull/144.

This PR replaces https://github.com/logstash-plugins/logstash-output-kafka/pull/144.
