### PR TITLE
 #123 fix byte array value_serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.0.4
+  - Bugfix: Fixed a bug that broke using `org.apache.kafka.common.serialization.ByteArraySerializer` as the `value_serializer`
+
 ## 7.0.3
   - Bugfix: Sends are now retried until successful. Previously, failed transmissions to Kafka
     could have been lost by the KafkaProducer library. Now we verify transmission explicitly.

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '7.0.3'
+  s.version         = '7.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = 'Output events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fix the most common problematic use case arising from #123 here by making byte array serialization for the value work.

There are only 2 functional changes (I simply factored out the shared sending logic, there isn't really a big change here in general) here:

* send `byte[]` to the Kafka producer record constructor when using `ByteArraySerializer`
* raise an error if using anything but `ByteArraySerializer` or `StringSerializer`, all the others don't work anyways