### PR TITLE
Replace version matrix with link to Kafka compatibility reference.

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -20,8 +20,11 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-Write events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on
-the broker.
+Write events to a Kafka topic. 
+
+This plugin uses Kafka Client 0.9.0.1. For broker compatibility, see the official https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix[Kafka compatibility reference].
+
+If you're using a plugin version that was released after {version}, see the https://www.elastic.co/guide/en/logstash/master/plugins-inputs-kafka.html[latest plugin documentation] for updated information about Kafka compatibility. If you require features not yet available in this plugin (including client version upgrades), please file an issue with details about what you need..
 
 The only required configuration is the topic name. The default codec is json,
 so events will be persisted on the broker in json format. If you select a codec of plain,


### PR DESCRIPTION
Kafka clients version was determined by checking the .gemspec
Parent issue: #156

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
