### PR TITLE
Log 'RecordTooLargeException' errors as warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.1.1
+  - Changed Kafka send errors to log as warn [#179](https://github.com/logstash-plugins/logstash-output-kafka/pull/179)
+
 ## 7.1.0
   - Internal: Update build to gradle
   - Upgrade Kafka client to version 1.1.0

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -270,7 +270,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
           result = future.get()
         rescue => e
           # TODO(sissel): Add metric to count failures, possibly by exception type.
-          logger.debug? && logger.debug("KafkaProducer.send() failed: #{e}", :exception => e);
+          logger.warn("KafkaProducer.send() failed: #{e}", :exception => e)
           failures << batch[i]
         end
       end

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '7.1.0'
+  s.version         = '7.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to a Kafka topic"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This is a common error, which cannot be fixed without changing Logstash setting
and should not be hidden as a debug log entry.

Fixes #177 