### PR TITLE
Handle RecordTooLargeException

### DIFF
--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -9,7 +9,7 @@ else
 fi
 
 echo "Downloading Kafka version $KAFKA_VERSION"
-curl -s -o kafka.tgz "http://ftp.wayne.edu/apache/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
+curl -s -o kafka.tgz "https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
 mkdir kafka && tar xzf kafka.tgz -C kafka --strip-components 1
 
 echo "Starting ZooKeeper"

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -262,6 +262,9 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
         rescue org.apache.kafka.common.errors.InterruptException => e
           failures << record
           nil
+        rescue org.apache.kafka.common.errors.RecordTooLargeException => e
+          failures << record
+          nil
         rescue org.apache.kafka.common.errors.SerializationException => e
           # TODO(sissel): Retrying will fail because the data itself has a problem serializing.
           # TODO(sissel): Let's add DLQ here.


### PR DESCRIPTION
RecordTooLargeException is similar to SerializationException.  The retry will fail forever and will be caught in an endless loop.

See issue https://github.com/logstash-plugins/logstash-output-kafka/issues/190
