### PR TITLE
fix RECEIVE_BUFFER_CONFIG data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.1.3
+  - Fixed handling of receive buffer bytes setting [#204](https://github.com/logstash-plugins/logstash-output-kafka/pull/204)
+
 ## 7.1.2
   - Fixed handling of two settings that weren't wired to the kafka client [#198](https://github.com/logstash-plugins/logstash-output-kafka/pull/198)
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -323,7 +323,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       props.put(kafka::LINGER_MS_CONFIG, linger_ms.to_s)
       props.put(kafka::MAX_REQUEST_SIZE_CONFIG, max_request_size.to_s)
       props.put(kafka::METADATA_MAX_AGE_CONFIG, metadata_max_age_ms) unless metadata_max_age_ms.nil?
-      props.put(kafka::RECEIVE_BUFFER_CONFIG, receive_buffer_bytes) unless receive_buffer_bytes.nil?
+      props.put(kafka::RECEIVE_BUFFER_CONFIG, receive_buffer_bytes.to_s) unless receive_buffer_bytes.nil?
       props.put(kafka::RECONNECT_BACKOFF_MS_CONFIG, reconnect_backoff_ms) unless reconnect_backoff_ms.nil?
       props.put(kafka::REQUEST_TIMEOUT_MS_CONFIG, request_timeout_ms) unless request_timeout_ms.nil?
       props.put(kafka::RETRIES_CONFIG, retries.to_s) unless retries.nil?

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '7.1.2'
+  s.version         = '7.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to a Kafka topic"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This plugin has been broken since the receive_buffer_bytes option has been correctly passed to the kafka client in https://github.com/logstash-plugins/logstash-output-kafka/pull/198, causing the client's instantiation to raise an exception due to incorrect data type of the value of this setting.

Currently the [ci is failing](https://travis-ci.org/logstash-plugins/logstash-output-kafka/jobs/420116520#L1299) because of this data type mismatch.

This PR changes the type of RECEIVE_BUFFER_CONFIG to string, and we can see that the tests no longer fail.

