### PR TITLE
Remove unnecessary sleep after exhausted retries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=master
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.x
+    env: LOGSTASH_BRANCH=6.7
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.5
+    env: LOGSTASH_BRANCH=7.0
   - rvm: jruby-1.7.27
     env: LOGSTASH_BRANCH=5.6
   fast_finish: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.0.1
+  - Fixed issue with unnecessary sleep after retries exhausted [#216](https://github.com/logstash-plugins/logstash-output-kafka/pull/216)
+
 ## 8.0.0
   - Removed obsolete `block_on_buffer_full`, `ssl` and `timeout_ms` options
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -225,7 +225,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   end
 
   def retrying_send(batch)
-    remaining = @retries;
+    remaining = @retries
 
     while batch.any?
       if !remaining.nil?
@@ -275,13 +275,16 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       break if failures.empty?
 
       # Otherwise, retry with any failed transmissions
-      batch = failures
-      delay = @retry_backoff_ms / 1000.0
-      logger.info("Sending batch to Kafka failed. Will retry after a delay.", :batch_size => batch.size,
-                  :failures => failures.size, :sleep => delay);
-      sleep(delay)
+      if remaining != nil && remaining < 0
+        logger.info("Sending batch to Kafka failed.", :batch_size => batch.size,:failures => failures.size)
+      else
+        delay = @retry_backoff_ms / 1000.0
+        logger.info("Sending batch to Kafka failed. Will retry after a delay.", :batch_size => batch.size,
+                    :failures => failures.size, :sleep => delay)
+        batch = failures
+        sleep(delay)
+      end
     end
-
   end
 
   def close

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -275,12 +275,11 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       break if failures.empty?
 
       # Otherwise, retry with any failed transmissions
-      if remaining != nil && remaining < 0
-        logger.info("Sending batch to Kafka failed.", :batch_size => batch.size,:failures => failures.size)
-      else
+      if remaining.nil? || remaining >= 0
         delay = @retry_backoff_ms / 1000.0
         logger.info("Sending batch to Kafka failed. Will retry after a delay.", :batch_size => batch.size,
-                    :failures => failures.size, :sleep => delay)
+                                                                                :failures => failures.size,
+                                                                                :sleep => delay)
         batch = failures
         sleep(delay)
       end

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '8.0.0'
+  s.version         = '8.0.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Writes events to a Kafka topic"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Also fixes up some issues with logging, where the batch size was calculated
incorrectly.
