### PR TITLE
[Backport to 7.x] Remove unnecessary sleep after exhausted retries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=master
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.x
+    env: LOGSTASH_BRANCH=6.7
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.0
+    env: LOGSTASH_BRANCH=7.0
   - rvm: jruby-1.7.27
     env: LOGSTASH_BRANCH=5.6
   fast_finish: true
@@ -18,3 +18,4 @@ before_script: ci/build.sh
 script: ci/run.sh
 after_script: ci/cleanup.sh
 jdk: oraclejdk8
+before_install: gem install bundler -v '< 2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.3.2
+  - Fixed issue with unnecessary sleep after retries exhausted [#216](https://github.com/logstash-plugins/logstash-output-kafka/pull/216)
+
 ## 7.3.1
   - Added support for kafka property `ssl.endpoint.identification.algorithm` [#213](https://github.com/logstash-plugins/logstash-output-kafka/pull/213)
 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -281,12 +281,11 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       break if failures.empty?
 
       # Otherwise, retry with any failed transmissions
-      if remaining != nil && remaining < 0
-        logger.info("Sending batch to Kafka failed.", :batch_size => batch.size,:failures => failures.size)
-      else
+      if remaining.nil? || remaining >= 0
         delay = @retry_backoff_ms / 1000.0
         logger.info("Sending batch to Kafka failed. Will retry after a delay.", :batch_size => batch.size,
-                    :failures => failures.size, :sleep => delay)
+                                                                                :failures => failures.size,
+                                                                                :sleep => delay)
         batch = failures
         sleep(delay)
       end

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -231,7 +231,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   end
 
   def retrying_send(batch)
-    remaining = @retries;
+    remaining = @retries
 
     while batch.any?
       if !remaining.nil?
@@ -281,13 +281,16 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       break if failures.empty?
 
       # Otherwise, retry with any failed transmissions
-      batch = failures
-      delay = @retry_backoff_ms / 1000.0
-      logger.info("Sending batch to Kafka failed. Will retry after a delay.", :batch_size => batch.size,
-                  :failures => failures.size, :sleep => delay);
-      sleep(delay)
+      if remaining != nil && remaining < 0
+        logger.info("Sending batch to Kafka failed.", :batch_size => batch.size,:failures => failures.size)
+      else
+        delay = @retry_backoff_ms / 1000.0
+        logger.info("Sending batch to Kafka failed. Will retry after a delay.", :batch_size => batch.size,
+                    :failures => failures.size, :sleep => delay)
+        batch = failures
+        sleep(delay)
+      end
     end
-
   end
 
   def close

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '7.3.1'
+  s.version         = '7.3.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Writes events to a Kafka topic"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Also fixes up some issues with logging, where the batch size was calculated
incorrectly.

Update .travis.yml build targets