### PR TITLE
Backport to 6.x of fixes from more recent branches 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,10 @@
 sudo: false
 language: ruby
 cache: bundler
-env: 
 rvm:
-- jruby-1.7.25
-matrix:
-  include:
-  - rvm: jruby-9.1.10.0
-    env: LOGSTASH_BRANCH=master
-  - rvm: jruby-1.7.25
-    env: LOGSTASH_BRANCH=5.x
-  fast_finish: true
+  - jruby-1.7.25
+env:
+  - KAFKA_VERSION=0.10.2.2 LOGSTASH_BRANCH=5.6
 install: true
 script: ci/build.sh
 jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ matrix:
 install: true
 script: ci/build.sh
 jdk: oraclejdk8
+before_install: gem install bundler -v '< 2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 6.2.4
-  - Improve error logging when a producer cannot be created.
- 
+  - Backport of fixes from more recent branches:
+    - Fixed unnecessary sleep after exhausted retries [#166](https://github.com/logstash-plugins/logstash-output-kafka/pull/166)
+    - Changed Kafka send errors to log as warn [#179](https://github.com/logstash-plugins/logstash-output-kafka/pull/179)
+
 ## 6.2.3
   - Bugfix: Sends are now retried until successful. Previously, failed transmissions to Kafka
     could have been lost by the KafkaProducer library. Now we verify transmission explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.2.4
+  - Improve error logging when a producer cannot be created.
+ 
 ## 6.2.3
   - Bugfix: Sends are now retried until successful. Previously, failed transmissions to Kafka
     could have been lost by the KafkaProducer library. Now we verify transmission explicitly.

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,4 +1,3 @@
-export KAFKA_VERSION=0.10.1.0
 ./kafka_test_setup.sh
 bundle install
 bundle exec rake vendor

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -285,7 +285,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
       # Otherwise, retry with any failed transmissions
       batch = failures
-      delay = 1.0 / @retry_backoff_ms
+      delay = @retry_backoff_ms / 1000.0
       logger.info("Sending batch to Kafka failed. Will retry after a delay.", :batch_size => batch.size,
                   :failures => failures.size, :sleep => delay);
       sleep(delay)

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -234,7 +234,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   end
 
   def retrying_send(batch)
-    remaining = @retries;
+    remaining = @retries
 
     while batch.any?
       if !remaining.nil?
@@ -284,13 +284,16 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       break if failures.empty?
 
       # Otherwise, retry with any failed transmissions
-      batch = failures
-      delay = @retry_backoff_ms / 1000.0
-      logger.info("Sending batch to Kafka failed. Will retry after a delay.", :batch_size => batch.size,
-                  :failures => failures.size, :sleep => delay);
-      sleep(delay)
+      if remaining != nil && remaining < 0
+        logger.info("Sending batch to Kafka failed.", :batch_size => batch.size,:failures => failures.size)
+      else
+        delay = @retry_backoff_ms / 1000.0
+        logger.info("Sending batch to Kafka failed. Will retry after a delay.", :batch_size => batch.size,
+                    :failures => failures.size, :sleep => delay)
+        batch = failures
+        sleep(delay)
+      end
     end
-
   end
 
   def close

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -333,7 +333,9 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
 
       org.apache.kafka.clients.producer.KafkaProducer.new(props)
     rescue => e
-      logger.error("Unable to create Kafka producer from given configuration", :kafka_error_message => e)
+      logger.error("Unable to create Kafka producer from given configuration",
+                   :kafka_error_message => e,
+                   :cause => e.respond_to?(:getCause) ? e.getCause() : nil)
       raise e
     end
   end

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.name            = 'logstash-output-kafka'
   s.version         = '6.2.4'
   s.licenses        = ['Apache License (2.0)']
-  s.summary         = "Writes events to a Kafka topic"
+  s.summary         = 'Output events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on the broker'
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ['Elasticsearch']
   s.email           = 'info@elastic.co'

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,9 +1,9 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '6.2.3'
+  s.version         = '6.2.4'
   s.licenses        = ['Apache License (2.0)']
-  s.summary         = 'Output events to a Kafka topic. This uses the Kafka Producer API to write messages to a topic on the broker'
+  s.summary         = "Writes events to a Kafka topic"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ['Elasticsearch']
   s.email           = 'info@elastic.co'


### PR DESCRIPTION
Fixed unnecessary sleep after exhausted retries #166
Changed Kafka send errors to log as warn #179