### PR TITLE
Fixed Kafka client avoiding exponential reconnection backoff because...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,37 @@
+## 8.0.3
+  - Fixed Kafka client avoiding exponential reconnection backoff because of `reconnect_backoff_ms` default value.
+    Removed default value of `reconnect_backoff_ms` option.
+    Added `reconnect_backoff_max_ms` option to set max backoff.
+    [#221](https://github.com/logstash-plugins/logstash-output-kafka/pull/221)
+
 ## 8.0.1
-  - Fixed issue with unnecessary sleep after retries exhausted [#216](https://github.com/logstash-plugins/logstash-output-kafka/pull/216)
+  - Fixed issue with unnecessary sleep after retries exhausted
+    [#216](https://github.com/logstash-plugins/logstash-output-kafka/pull/216)
 
 ## 8.0.0
   - Removed obsolete `block_on_buffer_full`, `ssl` and `timeout_ms` options
 
 ## 7.3.1
-  - Added support for kafka property `ssl.endpoint.identification.algorithm` [#213](https://github.com/logstash-plugins/logstash-output-kafka/pull/213)
+  - Added support for kafka property `ssl.endpoint.identification.algorithm`
+    [#213](https://github.com/logstash-plugins/logstash-output-kafka/pull/213)
 
 ## 7.3.0
   - Changed Kafka client to version 2.1.0
 
 ## 7.2.1
-  - Changed Kafka client to version 2.0.1 [#209](https://github.com/logstash-plugins/logstash-output-kafka/pull/209)
+  - Changed Kafka client to version 2.0.1
+    [#209](https://github.com/logstash-plugins/logstash-output-kafka/pull/209)
 
 ## 7.2.0
   - Upgrade Kafka client to version 2.0.0
 
 ## 7.1.2
-  - Fixed handling of two settings that weren't wired to the kafka client [#198](https://github.com/logstash-plugins/logstash-output-kafka/pull/198)
+  - Fixed handling of two settings that weren't wired to the kafka client
+    [#198](https://github.com/logstash-plugins/logstash-output-kafka/pull/198)
 
 ## 7.1.1
-  - Changed Kafka send errors to log as warn [#179](https://github.com/logstash-plugins/logstash-output-kafka/pull/179)
+  - Changed Kafka send errors to log as warn
+    [#179](https://github.com/logstash-plugins/logstash-output-kafka/pull/179)
 
 ## 7.1.0
   - Internal: Update build to gradle
@@ -113,20 +124,21 @@
 
 ## 4.0.0
   - Republish all the gems under jruby.
-  - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
+  - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. 
+    See https://github.com/elastic/logstash/issues/5141
   
 ## 3.0.0
- - GA release of Kafka Output to support 0.9 broker
+  - GA release of Kafka Output to support 0.9 broker
 
 ## 3.0.0.beta4
- - Fix Log4j warnings by setting up the logger (#62)
+  - Fix Log4j warnings by setting up the logger (#62)
 
 ## 3.0.0.beta3
- - Use jar dependencies
- - Fixed snappy compression issue
+  - Use jar dependencies
+  - Fixed snappy compression issue
 
 ## 3.0.0.beta2
- - Internal: Update gemspec dependency
+  - Internal: Update gemspec dependency
 
 ## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
@@ -136,23 +148,23 @@
   - New dependency requirements for logstash-core for the 5.0 release
 
 ## 3.0.0.beta1
- - Note: breaking changes in this version, and not backward compatible with Kafka 0.8 broker. 
-   Please read carefully before installing
- - Breaking: Changed default codec from json to plain. Json codec is really slow when used 
-   with inputs because inputs by default are single threaded. This makes it a bad
-   first user experience. Plain codec is a much better default. 
- - Moved internal APIs to use Kafka's Java API directly instead of jruby-kafka. This
-   makes it consistent with logstash-input-kafka
- - Breaking: Change in configuration options
- - Added SSL options so you can connect securely to a 0.9 Kafka broker
+  - Note: breaking changes in this version, and not backward compatible with Kafka 0.8 broker. 
+    Please read carefully before installing
+  - Breaking: Changed default codec from json to plain. Json codec is really slow when used 
+    with inputs because inputs by default are single threaded. This makes it a bad
+    first user experience. Plain codec is a much better default. 
+  - Moved internal APIs to use Kafka's Java API directly instead of jruby-kafka. This
+    makes it consistent with logstash-input-kafka
+  - Breaking: Change in configuration options
+  - Added SSL options so you can connect securely to a 0.9 Kafka broker
 
 ## 2.0.2
- - [Internal] Pin jruby-kafka to v1.5
+  - [Internal] Pin jruby-kafka to v1.5
 
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
-   instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
- - Dependency on logstash-core update to 2.0
+  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
+  - Dependency on logstash-core update to 2.0
 
 # ## 2.0.0.beta.1
- - Change to 0.8.2 version of Kafka producer. This will unfortunately break existing configuration, but has a lot of enhancements and fixes.
+  - Change to 0.8.2 version of Kafka producer. This will unfortunately break existing configuration, but has a lot of enhancements and fixes.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -75,6 +75,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-metadata_max_age_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-receive_buffer_bytes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-reconnect_backoff_ms>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-reconnect_backoff_max_ms>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-request_timeout_ms>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-retries>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_backoff_ms>> |<<number,number>>|No
@@ -259,9 +260,22 @@ The size of the TCP receive buffer to use when reading data
 ===== `reconnect_backoff_ms` 
 
   * Value type is <<number,number>>
-  * Default value is `10`
+  * There is no default value for this setting.
 
-The amount of time to wait before attempting to reconnect to a given host when a connection fails.
+The base amount of time to wait before attempting to reconnect to a given host.
+This avoids repeatedly connecting to a host in a tight loop.
+This backoff applies to all connection attempts by the client to a broker.
+
+[id="plugins-{type}s-{plugin}-reconnect_backoff_max_ms"]
+===== `reconnect_backoff_max_ms`
+
+  * Value type is <<number,number>>
+  * There is no default value for this setting.
+
+The maximum amount of time to wait when reconnecting to a broker that has repeatedly failed to connect.
+If provided, the backoff per host will increase exponentially for each consecutive connection failure,
+up to this maximum.
+After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
 
 [id="plugins-{type}s-{plugin}-request_timeout_ms"]
 ===== `request_timeout_ms` 

--- a/lib/logstash/outputs/kafka.rb
+++ b/lib/logstash/outputs/kafka.rb
@@ -102,8 +102,15 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
   config :metadata_max_age_ms, :validate => :number, :default => 300000
   # The size of the TCP receive buffer to use when reading data
   config :receive_buffer_bytes, :validate => :number, :default => 32768
-  # The amount of time to wait before attempting to reconnect to a given host when a connection fails.
-  config :reconnect_backoff_ms, :validate => :number, :default => 10
+  # The base amount of time to wait before attempting to reconnect to a given host.
+  # This avoids repeatedly connecting to a host in a tight loop.
+  # This backoff applies to all connection attempts by the client to a broker.
+  config :reconnect_backoff_ms, :validate => :number
+  # The maximum amount of time to wait when reconnecting to a broker that has repeatedly failed to connect.
+  # If provided, the backoff per host will increase exponentially for each consecutive connection failure,
+  # up to this maximum.
+  # After calculating the backoff increase, 20% random jitter is added to avoid connection storms.
+  config :reconnect_backoff_max_ms, :validate => :number
   # The configuration controls the maximum amount of time the client will wait
   # for the response of a request. If the response is not received before the timeout
   # elapses the client will resend the request if necessary or fail the request if
@@ -323,6 +330,7 @@ class LogStash::Outputs::Kafka < LogStash::Outputs::Base
       props.put(kafka::METADATA_MAX_AGE_CONFIG, metadata_max_age_ms) unless metadata_max_age_ms.nil?
       props.put(kafka::RECEIVE_BUFFER_CONFIG, receive_buffer_bytes.to_s) unless receive_buffer_bytes.nil?
       props.put(kafka::RECONNECT_BACKOFF_MS_CONFIG, reconnect_backoff_ms) unless reconnect_backoff_ms.nil?
+      props.put(kafka::RECONNECT_BACKOFF_MAX_MS_CONFIG, reconnect_backoff_max_ms) unless reconnect_backoff_max_ms.nil?
       props.put(kafka::REQUEST_TIMEOUT_MS_CONFIG, request_timeout_ms) unless request_timeout_ms.nil?
       props.put(kafka::RETRIES_CONFIG, retries.to_s) unless retries.nil?
       props.put(kafka::RETRY_BACKOFF_MS_CONFIG, retry_backoff_ms.to_s) 

--- a/logstash-output-kafka.gemspec
+++ b/logstash-output-kafka.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-kafka'
-  s.version         = '8.0.1'
+  s.version         = '8.0.3'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Writes events to a Kafka topic"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
...`reconnect_backoff_ms` is having a default value.

Removed default value of `reconnect_backoff_ms` option
Added `reconnect_backoff_max_ms` option to set max backoff

