### PR TITLE
Point users+contributors to integration source

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,11 @@
-Please post all product and debugging questions on our [forum](https://discuss.elastic.co/c/logstash). Your questions will reach our wider community members there, and if we confirm that there is a bug, then we can open a new issue here.
+## Kafka Output Plugin's Issue Tracker Has Moved
 
-For all general issues, please provide the following details for fast resolution:
+The Kafka Output Plugin is now a part of the [Kafka Integration Plugin][integration-source]. 
+This project remains open for backports of fixes from that project to the 8.x series where possible, but issues should first be filed on the [integration plugin][integration-issues].
 
-- Version:
-- Operating System:
-- Config File (if you have sensitive info, please remove it):
-- Sample Data:
-- Steps to Reproduce:
+Please post all product and debugging questions on our [forum][logstash-forum].
+Your questions will reach our wider community members there. If we confirm that there is a bug, then we can open a new issue on the appropriate project.
+
+[integration-source]: https://github.com/logstash-plugins/logstash-integration-kafka
+[integration-issues]: https://github.com/logstash-plugins/logstash-integration-kafka/issues/
+[logstash-forum]: https://discuss.elastic.co/c/logstash

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,13 @@
+## Kafka Output Plugin's Source Has Moved
+
+This Kafka Output Plugin is now a part of the [Kafka Integration Plugin][integration-source]. This project remains open for backports of fixes from that project to the 8.x series where possible, but pull-requests should first be made on the [integration plugin][integration-pull-requests].
+
+If you have already made commits on a clone of this stand-alone repository, it's ok! Go ahead and open the Pull Request here, and open an Issue linking to it on the [integration plugin][integration-issues] -- we'll work with you to sort it all out and to get the backport applied.
+
+## Contributor Agreement
+
 Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
+
+[integration-source]: https://github.com/logstash-plugins/logstash-integration-kafka
+[integration-issues]: https://github.com/logstash-plugins/logstash-integration-kafka/issues/
+[integration-pull-requests]: https://github.com/logstash-plugins/logstash-integration-kafka/pulls

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This is a plugin for [Logstash](https://github.com/elastic/logstash).
 
 It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
 
+## Kafka Output Plugin Has Moved
+
+This Kafka Output Plugin is now a part of the [Kafka Integration Plugin][integration-source]. This project remains open for backports of fixes from that project to the 8.x series where possible, but issues should first be filed on the [integration plugin][integration-issues].
+
+[integration-source]: https://github.com/logstash-plugins/logstash-integration-kafka
+[integration-issues]: https://github.com/logstash-plugins/logstash-integration-kafka/issues/
+
+
 ## Documentation
 
 Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -3,10 +3,10 @@
 :default_codec: plain
 
 /////////////////////////////////////////////
-// Kafka Output Plugin Source Has Moved  //
+// Kafka Output Plugin Source Has Moved    //
 // --------------------------------------- //
-// The Kafka Output Plugin is now a part //
-// of the Kafka Integration.            //
+// The Kafka Output Plugin is now a part   //
+// of the Kafka Integration.               //
 //                                         //
 // This stand-alone plugin project remains //
 // open for backports to the 8.x series.   //

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -2,6 +2,17 @@
 :type: output
 :default_codec: plain
 
+/////////////////////////////////////////////
+// Kafka Output Plugin Source Has Moved  //
+// --------------------------------------- //
+// The Kafka Output Plugin is now a part //
+// of the Kafka Integration.            //
+//                                         //
+// This stand-alone plugin project remains //
+// open for backports to the 8.x series.   //
+/////////////////////////////////////////////
+
+
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////


### PR DESCRIPTION
The forward-moving source of this plugin is now a part of the Kafka Integration. This PR is intended to point users and contributors to the new integration repo.