### PR TITLE
update matrix and kafka source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ language: ruby
 cache: bundler
 matrix:
   include:
-  - rvm: jruby-9.1.13.0
+  - rvm: jruby-9.2.8.0
     env: LOGSTASH_BRANCH=master
+  - rvm: jruby-9.2.8.0
+    env: LOGSTASH_BRANCH=7.x
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=6.x
   - rvm: jruby-9.1.13.0

--- a/kafka_test_setup.sh
+++ b/kafka_test_setup.sh
@@ -9,7 +9,7 @@ else
 fi
 
 echo "Downloading Kafka version $KAFKA_VERSION"
-curl -s -o kafka.tgz "http://ftp.wayne.edu/apache/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
+curl -s -o kafka.tgz "https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.11-$KAFKA_VERSION.tgz"
 mkdir kafka && tar xzf kafka.tgz -C kafka --strip-components 1
 
 echo "Starting ZooKeeper"


### PR DESCRIPTION
 - Ensures that the matrix runs on 7.x
 - downloads kafka from archive.apache.org (wayne.edu no longer has older releases)