### PR TITLE
Test: avoid insist gem usage

### DIFF
--- a/spec/unit/outputs/kafka_spec.rb
+++ b/spec/unit/outputs/kafka_spec.rb
@@ -11,14 +11,14 @@ describe "outputs/kafka" do
   context 'when initializing' do
     it "should register" do
       output = LogStash::Plugin.lookup("output", "kafka").new(simple_kafka_config)
-      expect {output.register}.to_not raise_error
+      expect { output.register }.to_not raise_error
     end
 
     it 'should populate kafka config with default values' do
       kafka = LogStash::Outputs::Kafka.new(simple_kafka_config)
-      insist {kafka.bootstrap_servers} == 'localhost:9092'
-      insist {kafka.topic_id} == 'test'
-      insist {kafka.key_serializer} == 'org.apache.kafka.common.serialization.StringSerializer'
+      expect(kafka.bootstrap_servers).to eql 'localhost:9092'
+      expect(kafka.topic_id).to eql 'test'
+      expect(kafka.key_serializer).to eql 'org.apache.kafka.common.serialization.StringSerializer'
     end
   end
 
@@ -55,7 +55,7 @@ describe "outputs/kafka" do
       expect { kafka.register }.to raise_error(LogStash::ConfigurationError, /ssl_truststore_location must be set when SSL is enabled/)
     end
   end
-  
+
   context "when KafkaProducer#send() raises an exception" do
     let(:failcount) { (rand * 10).to_i }
     let(:sendcount) { failcount + 1 }


### PR DESCRIPTION
## Kafka Output Plugin's Source Has Moved

> This Kafka Output Plugin is now a part of the [Kafka Integration Plugin][integration-source]. This project remains open for backports of fixes from that project to the 8.x series where possible, but pull-requests should first be made on the [integration plugin][integration-pull-requests].

> If you have already made commits on a clone of this stand-alone repository, it's ok! Go ahead and open the Pull Request here, and open an Issue linking to it on the [integration plugin][integration-issues] -- we'll work with you to sort it all out and to get the backport applied.

~ backport of https://github.com/logstash-plugins/logstash-integration-kafka/commit/115e6f6c31401697e3f3620908b89f5d0444716b